### PR TITLE
fix: close modal on creating comments

### DIFF
--- a/shuffle/app/(frontend)/polls/[slug]/client.tsx
+++ b/shuffle/app/(frontend)/polls/[slug]/client.tsx
@@ -162,6 +162,7 @@ const Poll = ({
         author_name: user?.fullName ?? null,
         author_avatar_url: user?.profileImageUrl ?? null,
       });
+      setIsCreating(false);
     },
     [
       amplitude,


### PR DESCRIPTION
On creating a new comment, modal should automatically close after pressing "Add new comment" button.