### PR TITLE
fix: stop requesting polls on new poll page

### DIFF
--- a/shuffle/providers/CurrentPollProvider.tsx
+++ b/shuffle/providers/CurrentPollProvider.tsx
@@ -48,6 +48,7 @@ const CurrentPollProvider = ({ children }: PropsWithChildren) => {
   // Fetch
 
   const currentPollQuery = useQuery(["polls", currentPollSlug], async () => {
+    if (pathname === "/polls/new") return null;
     if (!currentPollSlug) return undefined;
     const { data } = await axios.get(`/api/polls/${currentPollSlug}`);
     return data as Poll;

--- a/shuffle/providers/CurrentPollProvider.tsx
+++ b/shuffle/providers/CurrentPollProvider.tsx
@@ -48,8 +48,7 @@ const CurrentPollProvider = ({ children }: PropsWithChildren) => {
   // Fetch
 
   const currentPollQuery = useQuery(["polls", currentPollSlug], async () => {
-    if (pathname === "/polls/new") return null;
-    if (!currentPollSlug) return undefined;
+    if (currentPollSlug === "new" || !currentPollSlug) return null;
     const { data } = await axios.get(`/api/polls/${currentPollSlug}`);
     return data as Poll;
   });


### PR DESCRIPTION
On the `polls/new` page we tried fetching polls, thus the request failed.
The request is now checks what page we're on, and requests polls only when needed.